### PR TITLE
Can now get a `FileResource` object if you need a local path of a resource for example

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace Spaze\SubresourceIntegrity;
 
+use Spaze\SubresourceIntegrity\Exceptions\CannotGetFilePathForRemoteResourceException;
 use Spaze\SubresourceIntegrity\Exceptions\HashFileException;
 use Spaze\SubresourceIntegrity\Exceptions\InvalidResourceAliasException;
 use Spaze\SubresourceIntegrity\Exceptions\ShouldNotHappenException;
@@ -147,6 +148,7 @@ class Config
 	/**
 	 * @param string|array<int, string> $resource
 	 * @throws ShouldNotHappenException
+	 * @throws CannotGetFilePathForRemoteResourceException
 	 */
 	private function localFile(string|array $resource, ?HtmlElement $targetHtmlElement = null): stdClass
 	{
@@ -171,7 +173,7 @@ class Config
 						if (!isset($this->resources[$value])) {
 							$resources[] = new StringResource($value);
 						} else {
-							$resources[] = new FileResource(sprintf('%s/%s', rtrim($this->localPrefix['path'], '/'), $this->getFilePath($value)));
+							$resources[] = $this->getFileResource($value);
 						}
 					}
 					$data = $this->fileBuilder->build($resources, $this->localPrefix['path'], $this->localPrefix['build'], $targetHtmlElement);
@@ -195,14 +197,23 @@ class Config
 
 
 	/**
-	 * @throws ShouldNotHappenException
+	 * @throws CannotGetFilePathForRemoteResourceException
 	 */
 	private function getFilePath(string $resource): string
 	{
 		if (is_array($this->resources[$resource])) {
-			throw new ShouldNotHappenException();
+			throw new CannotGetFilePathForRemoteResourceException($resource);
 		}
 		return ltrim($this->resources[$resource], '/');
+	}
+
+
+	/**
+	 * @throws CannotGetFilePathForRemoteResourceException
+	 */
+	public function getFileResource(string $resource): FileResource
+	{
+		return new FileResource(sprintf('%s/%s', rtrim($this->localPrefix['path'], '/'), $this->getFilePath($resource)));
 	}
 
 }

--- a/src/Exceptions/CannotGetFilePathForRemoteResourceException.php
+++ b/src/Exceptions/CannotGetFilePathForRemoteResourceException.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types = 1);
+
+namespace Spaze\SubresourceIntegrity\Exceptions;
+
+use Exception;
+use Throwable;
+
+class CannotGetFilePathForRemoteResourceException extends Exception
+{
+
+	public function __construct(string $resource, ?Throwable $previous = null)
+	{
+		parent::__construct("Cannot get file path for remote resource $resource", previous: $previous);
+	}
+
+}

--- a/src/Resource/FileResource.php
+++ b/src/Resource/FileResource.php
@@ -14,6 +14,12 @@ class FileResource implements ResourceInterface
 	}
 
 
+	public function getFilename(): string
+	{
+		return $this->filename;
+	}
+
+
 	/**
 	 * @throws CannotGetFileContentException
 	 */

--- a/tests/ConfigTest.phpt
+++ b/tests/ConfigTest.phpt
@@ -8,6 +8,7 @@ declare(strict_types = 1);
 
 namespace Spaze\SubresourceIntegrity;
 
+use Spaze\SubresourceIntegrity\Exceptions\CannotGetFilePathForRemoteResourceException;
 use Spaze\SubresourceIntegrity\Exceptions\DirectoryNotWritableException;
 use Spaze\SubresourceIntegrity\Exceptions\UnknownExtensionException;
 use Tester\Assert;
@@ -61,6 +62,26 @@ class ConfigTest extends TestCase
 		Assert::same('https://bar', $this->config->getUrl('foo', HtmlElement::Link));
 		Assert::same('/chuck/norris/waldo/quux.js', $this->config->getUrl('bar'));
 		Assert::same('/chuck/norris/waldo/quux.js', $this->config->getUrl('bar', HtmlElement::Script));
+	}
+
+
+	public function testGetFileResource(): void
+	{
+		$this->config->setLocalPrefix((object)[
+			'path' => '/chuck/norris/',
+		]);
+		$this->config->setResources([
+			'foo' => [
+				'url' => 'https://nope'
+			],
+			'bar' => '/waldo/quux.js',
+		]);
+		Assert::exception(function (): void {
+			$this->config->getFileResource('foo');
+		}, CannotGetFilePathForRemoteResourceException::class, 'Cannot get file path for remote resource foo');
+		$fileResource = $this->config->getFileResource('bar');
+		Assert::same('/chuck/norris/waldo/quux.js', $fileResource->getFilename());
+		Assert::same('js', $fileResource->getExtension());
 	}
 
 


### PR DESCRIPTION
You could get the same information from what you pass to `setLocalPrefix()` and `setResources()` so this is more of a utility method.