### PR TITLE
Use Latte's CamelCase constants

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": "^8.1",
-		"latte/latte": "^3.0",
+		"latte/latte": "^3.0.9",
 		"nette/di": "^3.0"
 	},
 	"autoload": {

--- a/tests/ConfigTest.phpt
+++ b/tests/ConfigTest.phpt
@@ -32,7 +32,7 @@ class ConfigTest extends TestCase
 
 	public function __construct()
 	{
-		$this->buildDir = '../temp/tests/' . getenv(Environment::THREAD);
+		$this->buildDir = '../temp/tests/' . getenv(Environment::VariableThread);
 		$this->tempDir = __DIR__ . '/' . $this->buildDir;
 		@mkdir(dirname($this->tempDir));  // intentionally @ - the dir might exist already
 		Helpers::purge($this->tempDir);


### PR DESCRIPTION
Latte 3.0.9 adds VersionId constant too so let's use that as a minimum