### PR TITLE
Test on PHP 8.4

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         php-version:
           - "8.3"
+          - "8.4"
         update-options:
           - ""
           - "--prefer-lowest"


### PR DESCRIPTION
nette/tester supports PHP 8.4 [now](https://github.com/nette/tester/releases/tag/v2.5.4) but other libs do not yet.