### PR TITLE
Latte 3.0.18 has reverted the "unquoted strings can contain +" feature

### DIFF
--- a/tests/Bridges/Latte/LatteExtensionTest.phpt
+++ b/tests/Bridges/Latte/LatteExtensionTest.phpt
@@ -65,17 +65,9 @@ class LatteExtensionTest extends TestCase
 		$this->assertFile($scripts[1], 'src', 'WALDO', $expectedBarHash);
 		$this->assertFile($scripts[2], 'src', "FOO\nWALDO", $expectedFooPlusBarHash);
 		$this->assertFile($scripts[3], 'src', "FOO\nwaldo + fred+baz WALDO", $expectedFooPluStringPlusBarHash);
-
-		// Starting with Latte 3.0.17, unquoted strings can contain +, so these behave differently
-		if (Engine::VersionId >= 30017) {
-			$this->assertFile($scripts[4], 'src', 'BAR', $expectedBarPlusBazHash);
-			$this->assertFile($scripts[5], 'src', 'BAR', $expectedBarPlusBazHash);
-			$this->assertFile($scripts[6], 'src', 'BAR', $expectedBarPlusBazHash);
-		} else {
-			$this->assertFile($scripts[4], 'src', "WALDO\nbaz", $expectedBarPlusStringHash);
-			$this->assertFile($scripts[5], 'src', "WALDO\nbaz", $expectedBarPlusStringHash);
-			$this->assertFile($scripts[6], 'src', "WALDO\nbaz", $expectedBarPlusStringHash);
-		}
+		$this->assertFile($scripts[4], 'src', "WALDO\nbaz", $expectedBarPlusStringHash);
+		$this->assertFile($scripts[5], 'src', "WALDO\nbaz", $expectedBarPlusStringHash);
+		$this->assertFile($scripts[6], 'src', "WALDO\nbaz", $expectedBarPlusStringHash);
 		$this->assertFile($scripts[7], 'src', 'FRED', $expectedBarPlusBazWithSpacesHash);
 
 		$styles = $domQuery->find('link[rel=stylesheet]');

--- a/tests/Bridges/Latte/template.latte
+++ b/tests/Bridges/Latte/template.latte
@@ -2,13 +2,9 @@
 {script bar empty-attribute, attribute => value}
 {script foo + bar empty-attribute, attribute => value}
 {script foo + 'waldo + fred+baz ' + bar empty-attribute, attribute => value}
-
-Parsed as a string 'bar+baz' in Latte 3.0.17 and newer, as 'bar' + 'baz' otherwise
 {script bar+baz empty-attribute, attribute => value}
 {script 'bar+baz' empty-attribute, attribute => value}
 {script bar + baz empty-attribute, attribute => value}
-
-Parsed as 'bar + baz' no matter the Latte version
 {script 'bar + baz' empty-attribute, attribute => value}
 
 {stylesheet foo empty-attribute, attribute => value}


### PR DESCRIPTION
See the discussion in https://github.com/nette/latte/discussions/369

This modifies the tests added in #26